### PR TITLE
Changed laravel/framework for illuminate/support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "laravel/framework": "5.*",
+        "illuminate/support": "5.2.*",
         "zendesk/zendesk_api_client_php": "2.*"
     },
     "autoload": {


### PR DESCRIPTION
:bulb: Changed `laravel/framework` for `illuminate/support` for better dependency management.

_This way the wrapper could be used in `laravel/lumen` without importing the whole `laravel/framework`._
