### PR TITLE
Bumped the supported Illuminate/Support version to 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~5.2",
+        "illuminate/support": "~5.4",
         "zendesk/zendesk_api_client_php": "2.*"
     },
     "autoload": {


### PR DESCRIPTION
Just bumped the supported version of Illuminate\Support to 5.4. Needed it for a project Im working on wouldn't install otherwise.