### PR TITLE
Add null & log drivers

### DIFF
--- a/config/zendesk-laravel.php
+++ b/config/zendesk-laravel.php
@@ -1,5 +1,6 @@
 <?php
 return [
+    'driver' => env('ZENDESK_DRIVER', 'api'),
     'subdomain' => env('ZENDESK_SUBDOMAIN',null),
     'username' => env('ZENDESK_USERNAME',null),
     'token' => env('ZENDESK_TOKEN',null)

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,10 @@ The username for the authenticating account.
 
 The API access token. You can create one at: `https://SUBDOMAIN.zendesk.com/agent/admin/api/settings`
 
+- `ZENDESK_DRIVER` _(Optional)_
+
+Set this to `null` or `log` to prevent calling the Zendesk API directly from your environment.
+
 ## Usage
 
 ### Facade

--- a/src/Providers/ZendeskServiceProvider.php
+++ b/src/Providers/ZendeskServiceProvider.php
@@ -1,26 +1,27 @@
 <?php namespace Huddle\Zendesk\Providers;
 
+use Huddle\Zendesk\Services\NullService;
 use Huddle\Zendesk\Services\ZendeskService;
-use Zendesk;
 use Illuminate\Support\ServiceProvider;
 
 class ZendeskServiceProvider extends ServiceProvider {
 
-	/**
-	 * Indicates if loading of the provider is deferred.
-	 *
-	 * @var bool
-	 */
-	protected $defer = false;
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = false;
 
-	/**
-	 * Register the service provider and merge config.
-	 *
-	 * @return void
-	 */
-	public function register() {
-	    $packageName = 'zendesk-laravel';
-	    $configPath = __DIR__.'/../../config/zendesk-laravel.php';
+    /**
+     * Register the service provider and merge config.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $packageName = 'zendesk-laravel';
+        $configPath = __DIR__.'/../../config/zendesk-laravel.php';
 
         $this->mergeConfigFrom(
             $configPath, $packageName
@@ -29,16 +30,22 @@ class ZendeskServiceProvider extends ServiceProvider {
         $this->publishes([
             $configPath => config_path(sprintf('%s.php', $packageName)),
         ]);
-	}
+    }
 
-	/**
-	 * Bind service to 'zendesk' for use with Facade
-	 *
-	 * @return void
-	 */
-	public function boot()
-	{
-        $this->app->bind('zendesk', ZendeskService::class);
-	}
+    /**
+     * Bind service to 'zendesk' for use with Facade.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->app->bind('zendesk', function () {
+            $driver = config('newsletter.driver', 'api');
+            if (is_null($driver) || $driver === 'log') {
+                return new NullService($driver === 'log');
+            }
 
+            return new ZendeskService;
+        });
+    }
 }

--- a/src/Providers/ZendeskServiceProvider.php
+++ b/src/Providers/ZendeskServiceProvider.php
@@ -40,7 +40,7 @@ class ZendeskServiceProvider extends ServiceProvider {
     public function boot()
     {
         $this->app->bind('zendesk', function () {
-            $driver = config('newsletter.driver', 'api');
+            $driver = config('zendesk-laravel.driver', 'api');
             if (is_null($driver) || $driver === 'log') {
                 return new NullService($driver === 'log');
             }

--- a/src/Services/NullService.php
+++ b/src/Services/NullService.php
@@ -1,0 +1,27 @@
+<?php namespace Huddle\Zendesk\Services;
+
+use Illuminate\Support\Facades\Log;
+
+class NullService {
+
+    /**
+     * @var bool
+     */
+    private $logCalls;
+
+    public function __construct(bool $logCalls = false)
+    {
+        $this->logCalls = $logCalls;
+    }
+
+    public function __call($name, $arguments)
+    {
+        if ($this->logCalls) {
+            Log::debug('Called Huddle Zendesk facade method: '.$name.' with:', $arguments);
+
+            return new self;
+        }
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Setting `ZENDESK_DRIVER=null` will disable this service.
Setting `ZENDESK_DRIVER=log` will disable this service while logging any calls made to it.

This is helpful in testing where I might not want to make real API calls to Zendesk.

`ZENDESK_DRIVER` defaults to `api` and will just use the normal `ZendeskService` so there isn't any breaking changes.