### PR TITLE
feat: update NullService to catch property access

### DIFF
--- a/src/Services/NullService.php
+++ b/src/Services/NullService.php
@@ -24,4 +24,15 @@ class NullService {
 
         return $this;
     }
+    
+    public function __get(string $name)
+    {
+        if ($this->logCalls) {
+            Log::debug('Called Huddle Zendesk facade property: '.$name);
+
+            return new self;
+        }
+
+        return $this;
+    }
 }


### PR DESCRIPTION
In our implementation, we rely on access to returned data when creating tickets.

This breaks when doing something like:

```php
$ticket = Zendesk::tickets()->create([...])->ticket;
```

By using `__get()` we can catch calls to properties and just continue to return the NullService as we do for methods.